### PR TITLE
Null check for hot_corner

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -11,7 +11,11 @@ let _id;
 function _disable_hot_corners() {
   // Used for gnome-shell 3.8, 3.10 and 3.12
   // Disables all hot corners
-  Main.layoutManager.hotCorners.forEach(function(hot_corner) { 
+  Main.layoutManager.hotCorners.forEach(function(hot_corner) {
+    if (!hot_corner) {
+      return;
+    }
+
     hot_corner._toggleOverview = function() {};
     hot_corner._pressureBarrier._trigger = function() {};
   });


### PR DESCRIPTION
On multi-monitor configurations, Main.layoutManager.hotCorners.length wil match the number of screens, but the elements for screens not having a top bar will be null. This causes the extension to fail in such configurations. This change addresses this issue.
