### PR TITLE
Add missing gnome-shell versions & Support GNOME 40

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "This extension disables the top left hot corners. You can still click on Activities or press the dedicated key to reach the overview. Since 3.8, should work with other extensions modifying the Activities button. On versions prior to 3.8, may not disable other hotcorners in multiscreen configurations and won't work on fallback/flashback mode.",
   "name": "No Topleft Hot Corner",
   "shell-version": [
-    "3.32", "3.30", "3.28", "3.26", "3.24", "3.22", "3.20", "3.18", "3.16", "3.14", "3.12", "3.10", "3.8"
+    "40", "3.38", "3.36", "3.34", "3.32", "3.30", "3.28", "3.26", "3.24", "3.22", "3.20", "3.18", "3.16", "3.14", "3.12", "3.10", "3.8"
   ],
   "url": "https://github.com/HROMANO/nohotcorner/",
   "uuid": "nohotcorner@azuri.free.fr",


### PR DESCRIPTION
 - Add missing old gnome-shell versions to avoid not support issue.
 - Add GNOME 40 to use it.

Signed-off-by: Yang Jeong Hun <onyxclover9931@gmail.com>